### PR TITLE
Add Python chat client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# TalkWithChatGPT Python Client
+
+This repository originally contains Keyboard Maestro macros to interact with ChatGPT. It now also includes a simple Python script that lets you chat with ChatGPT from the command line.
+
+## Requirements
+- Python 3
+- `requests` library (`pip install requests`)
+- An OpenAI API key set in the environment variable `OPENAI_API_KEY`
+
+## Usage
+Run the script from a terminal:
+```bash
+python chat.py
+```
+
+Type your message and press enter. Type `exit` or `quit` to end the conversation.
+
+## Keyboard Maestro Macros
+The file "🎙️Talk with ChatGPT 1.0 Macros.kmmacros" contains a collection of macros for interacting with ChatGPT on macOS.
+A helper macro in `chat_cli.kmmacros` launches the Python chat client via a hotkey (Ctrl+Option+K by default). Import the macro set into Keyboard Maestro to use it.

--- a/chat.py
+++ b/chat.py
@@ -1,0 +1,37 @@
+import os
+import requests
+import json
+
+def chat_loop():
+    api_key = os.getenv('OPENAI_API_KEY')
+    if not api_key:
+        raise SystemExit('Please set the OPENAI_API_KEY environment variable.')
+
+    messages = []
+    print('Starting conversation with ChatGPT. Type "exit" to quit.')
+    while True:
+        user_input = input('You: ')
+        if user_input.lower() in {'exit', 'quit'}:
+            break
+        messages.append({"role": "user", "content": user_input})
+        response = requests.post(
+            'https://api.openai.com/v1/chat/completions',
+            headers={
+                'Authorization': f'Bearer {api_key}',
+                'Content-Type': 'application/json'
+            },
+            json={
+                'model': 'gpt-3.5-turbo',
+                'messages': messages
+            }
+        )
+        if response.status_code != 200:
+            print('Error communicating with API:', response.text)
+            break
+        data = response.json()
+        reply = data['choices'][0]['message']['content']
+        messages.append({"role": "assistant", "content": reply})
+        print('ChatGPT:', reply)
+
+if __name__ == '__main__':
+    chat_loop()

--- a/chat_cli.kmmacros
+++ b/chat_cli.kmmacros
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+    <dict>
+        <key>Macros</key>
+        <array>
+            <dict>
+                <key>Actions</key>
+                <array>
+                    <dict>
+                        <key>ActionUID</key>
+                        <integer>1000</integer>
+                        <key>MacroActionType</key>
+                        <string>ExecuteShellScript</string>
+                        <key>Shell</key>
+                        <string>/bin/bash</string>
+                        <key>Text</key>
+                        <string>python ~/talkwithchatgpt/chat.py</string>
+                        <key>TimeOutAbortsMacro</key>
+                        <true/>
+                        <key>TrimResults</key>
+                        <true/>
+                        <key>UseText</key>
+                        <true/>
+                    </dict>
+                </array>
+                <key>Name</key>
+                <string>Launch Chat CLI</string>
+                <key>Triggers</key>
+                <array>
+                    <dict>
+                        <key>FireType</key>
+                        <string>Pressed</string>
+                        <key>KeyCode</key>
+                        <integer>40</integer>
+                        <key>MacroTriggerType</key>
+                        <string>HotKey</string>
+                        <key>Modifiers</key>
+                        <integer>4352</integer>
+                    </dict>
+                </array>
+                <key>UID</key>
+                <string>CLI-MACRO-UUID</string>
+            </dict>
+        </array>
+        <key>Name</key>
+        <string>Chat CLI Group</string>
+        <key>UID</key>
+        <string>CLI-GROUP-UUID</string>
+    </dict>
+</array>
+</plist>


### PR DESCRIPTION
## Summary
- add a simple Python script for chatting with ChatGPT via API
- document how to use the script in a new README
- add a Keyboard Maestro macro to launch the python chat client

## Testing
- `git status --short`
