### PR TITLE
Add voice dialog macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,5 @@ Type your message and press enter. Type `exit` or `quit` to end the conversation
 
 ## Keyboard Maestro Macros
 The file "🎙️Talk with ChatGPT 1.0 Macros.kmmacros" contains a collection of macros for interacting with ChatGPT on macOS.
+A new file `voice_macros.kmmacros` provides two simple macros that use AppleScript GUI scripting to open and close the ChatGPT application's voice dialogue window. Import this file if you want hotkeys for quickly toggling voice chat.
 A helper macro in `chat_cli.kmmacros` launches the Python chat client via a hotkey (Ctrl+Option+K by default). Import the macro set into Keyboard Maestro to use it.

--- a/voice_macros.kmmacros
+++ b/voice_macros.kmmacros
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+    <dict>
+        <key>Macros</key>
+        <array>
+            <dict>
+                <key>Actions</key>
+                <array>
+                    <dict>
+                        <key>ActionUID</key>
+                        <integer>1</integer>
+                        <key>MacroActionType</key>
+                        <string>ExecuteAppleScript</string>
+                        <key>Text</key>
+                        <string>tell application "ChatGPT" to activate
+tell application "System Events"
+    tell process "ChatGPT"
+        -- Adjust the button or menu path to open voice dialogue as needed
+        click button "Voice" of window 1
+    end tell
+end tell
+</string>
+                        <key>TimeOutAbortsMacro</key>
+                        <true/>
+                        <key>TrimResults</key>
+                        <true/>
+                        <key>UseText</key>
+                        <true/>
+                    </dict>
+                </array>
+                <key>Name</key>
+                <string>Open ChatGPT Voice Dialog</string>
+                <key>Triggers</key>
+                <array>
+                    <dict>
+                        <key>FireType</key>
+                        <string>Pressed</string>
+                        <key>KeyCode</key>
+                        <integer>9</integer>
+                        <key>MacroTriggerType</key>
+                        <string>HotKey</string>
+                        <key>Modifiers</key>
+                        <integer>4352</integer>
+                    </dict>
+                </array>
+                <key>UID</key>
+                <string>VOICE-OPEN-UUID</string>
+            </dict>
+            <dict>
+                <key>Actions</key>
+                <array>
+                    <dict>
+                        <key>ActionUID</key>
+                        <integer>2</integer>
+                        <key>MacroActionType</key>
+                        <string>ExecuteAppleScript</string>
+                        <key>Text</key>
+                        <string>tell application "ChatGPT" to activate
+tell application "System Events"
+    tell process "ChatGPT"
+        -- Adjust the button or menu path to close voice dialogue as needed
+        click button "Stop" of window 1
+    end tell
+end tell
+</string>
+                        <key>TimeOutAbortsMacro</key>
+                        <true/>
+                        <key>TrimResults</key>
+                        <true/>
+                        <key>UseText</key>
+                        <true/>
+                    </dict>
+                </array>
+                <key>Name</key>
+                <string>Close ChatGPT Voice Dialog</string>
+                <key>Triggers</key>
+                <array>
+                    <dict>
+                        <key>FireType</key>
+                        <string>Pressed</string>
+                        <key>KeyCode</key>
+                        <integer>13</integer>
+                        <key>MacroTriggerType</key>
+                        <string>HotKey</string>
+                        <key>Modifiers</key>
+                        <integer>4352</integer>
+                    </dict>
+                </array>
+                <key>UID</key>
+                <string>VOICE-CLOSE-UUID</string>
+            </dict>
+        </array>
+        <key>Name</key>
+        <string>ChatGPT Voice</string>
+        <key>UID</key>
+        <string>VOICE-GROUP-UUID</string>
+    </dict>
+</array>
+</plist>


### PR DESCRIPTION
## Summary
- add `voice_macros.kmmacros` with AppleScript GUI automation
- update README with instructions for the new macros

## Testing
- `python chat.py --help` *(fails: ModuleNotFoundError: No module named 'requests')*
- `python chat.py <<'EOF'
Hello
EOF` *(fails: ModuleNotFoundError: No module named 'requests')*